### PR TITLE
Add all languages supported by Snowball

### DIFF
--- a/src/Languages.jl
+++ b/src/Languages.jl
@@ -1,5 +1,6 @@
 module Languages
 	export Language, EnglishLanguage, SpanishLanguage, GermanLanguage
+	export isocode, name
 	export articles, definite_articles, indefinite_articles
 	export prepositions
 	export pronouns

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,51 @@
 abstract Language
-abstract EnglishLanguage <: Language
-abstract SpanishLanguage <: Language
-abstract GermanLanguage <: Language
-# ...
+
+# Languages currently supported by Snowball
+abstract DanishLanguage     <: Language
+abstract DutchLanguage      <: Language
+abstract EnglishLanguage    <: Language
+abstract FinnishLanguage    <: Language
+abstract FrenchLanguage     <: Language
+abstract GermanLanguage     <: Language
+abstract HungarianLanguage  <: Language
+abstract ItalianLanguage    <: Language
+abstract NorwegianLanguage  <: Language
+abstract PortugueseLanguage <: Language
+abstract RomanianLanguage   <: Language
+abstract RussianLanguage    <: Language
+abstract SpanishLanguage    <: Language
+abstract SwedishLanguage    <: Language
+abstract TurkishLanguage    <: Language
+
+# These are ISO 639-2T alpha-3 and ISO 639-3 codes
+isocode(lang::Type{DanishLanguage})     = "dan"
+isocode(lang::Type{DutchLanguage})      = "nld"
+isocode(lang::Type{EnglishLanguage})    = "eng"
+isocode(lang::Type{FinnishLanguage})    = "fin"
+isocode(lang::Type{FrenchLanguage})     = "fra"
+isocode(lang::Type{GermanLanguage})     = "deu"
+isocode(lang::Type{HungarianLanguage})  = "hun"
+isocode(lang::Type{ItalianLanguage})    = "ita"
+isocode(lang::Type{NorwegianLanguage})  = "nor"
+isocode(lang::Type{PortugueseLanguage}) = "por"
+isocode(lang::Type{RomanianLanguage})   = "ron"
+isocode(lang::Type{RussianLanguage})    = "rus"
+isocode(lang::Type{SpanishLanguage})    = "spa"
+isocode(lang::Type{SwedishLanguage})    = "swe"
+isocode(lang::Type{TurkishLanguage})    = "tur"
+
+name(lang::Type{DanishLanguage})     = "danish"
+name(lang::Type{DutchLanguage})      = "dutch"
+name(lang::Type{EnglishLanguage})    = "english"
+name(lang::Type{FinnishLanguage})    = "finnish"
+name(lang::Type{FrenchLanguage})     = "french"
+name(lang::Type{GermanLanguage})     = "german"
+name(lang::Type{HungarianLanguage})  = "hungarian"
+name(lang::Type{ItalianLanguage})    = "italian"
+name(lang::Type{NorwegianLanguage})  = "norwegian"
+name(lang::Type{PortugueseLanguage}) = "portuguese"
+name(lang::Type{RomanianLanguage})   = "romanian"
+name(lang::Type{RussianLanguage})    = "russian"
+name(lang::Type{SpanishLanguage})    = "spanish"
+name(lang::Type{SwedishLanguage})    = "swedish"
+name(lang::Type{TurkishLanguage})    = "turkish"


### PR DESCRIPTION
Together with a simple change I'm going to propose to Stemmers.jl,
this allows specifying the language of a document and to use
the correct stemmer. In the long term, we likely need a mechanism
to create the types based on an exhaustive list. For reference,
I have some code for the R package ISOcodes which downloads the
ISO 639-3 list from Wikipedia. Likewise, lists of stopwords could
be downloaded from the Snowball project.

In the future I think isocode() could get an additional argument
to choose between alpha-2, alpha-3/B and alpha-3/T codes, but I
wasn't sure how to implement this kind of enum argument.

The name() function is already used by TextAnalysis.jl. If you
think this name is the right choice, I can modify TextAnalysis.jl
to import it for Language.jl.