### PR TITLE
v0.4 compatibility

### DIFF
--- a/src/word_lists.jl
+++ b/src/word_lists.jl
@@ -2,7 +2,7 @@ for f in (:articles, :indefinite_articles, :definite_articles,
           :prepositions, :pronouns, :stopwords)
   @eval begin
     function ($f){T <: Language}(l::Type{T})
-      filename = Pkg.dir("Languages", "data", string($(f)), string(string(l), ".txt"))
+      filename = Pkg.dir("Languages", "data", string($(f)), string(string(l.name.name), ".txt"))
       return fetch_word_list(filename)
     end
   end


### PR DESCRIPTION
In 0.4, type names are printed with the module name. This changes
the code to directly access the local name of the type