### PR TITLE
Fixed 0.4 problems

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
-const _cache = Dict{String,Array}()
+const _cache = Dict{AbstractString,Array}()
 
-function fetch_word_list(filename::String)
+function fetch_word_list(filename::AbstractString)
   haskey(_cache, filename) && return _cache[filename] 
   try
     io = open(filename, "r")

--- a/src/word_lists.jl
+++ b/src/word_lists.jl
@@ -1,8 +1,7 @@
-for f in (:articles, :indefinite_articles, :definite_articles,
-          :prepositions, :pronouns, :stopwords)
+for f in ("articles", "indefinite_articles", "definite_articles", "prepositions", "pronouns", "stopwords")
   @eval begin
-    function ($f){T <: Language}(l::Type{T})
-      filename = Pkg.dir("Languages", "data", string($(f)), string(string(l.name.name), ".txt"))
+    function $(Symbol(f)){T <: Language}(l::Type{T})
+      filename = Pkg.dir("Languages", "data", $f, string(string(l.name.name), ".txt"))
       return fetch_word_list(filename)
     end
   end


### PR DESCRIPTION
In 0.4 symbols are prefixed with module names when converted to strings. This caused the data files to not be found.